### PR TITLE
Make more readable code in tokenizer(src/token.rs), with match expression.

### DIFF
--- a/src/gen_ir.rs
+++ b/src/gen_ir.rs
@@ -11,14 +11,13 @@
 // > in a later pass.
 
 use parse::{Node, NodeType};
-use {TokenType, Ctype, Type, Scope};
+use {Ctype, Scope, TokenType, Type};
 
 use std::sync::Mutex;
 
-lazy_static!{
+lazy_static! {
     static ref NUM_REGS: Mutex<usize> = Mutex::new(0);
     static ref NLABEL: Mutex<usize> = Mutex::new(1);
-
     static ref RETURN_LABEL: Mutex<usize> = Mutex::new(0);
     static ref RETURN_REG: Mutex<usize> = Mutex::new(0);
     static ref BREAK_LABEL: Mutex<usize> = Mutex::new(0);
@@ -116,8 +115,7 @@ impl From<TokenType> for IROp {
             TokenType::Minus => IROp::Sub,
             TokenType::Mul => IROp::Mul,
             TokenType::Div => IROp::Div,
-            TokenType::LeftAngleBracket |
-            TokenType::RightAngleBracket => IROp::LT,
+            TokenType::LeftAngleBracket | TokenType::RightAngleBracket => IROp::LT,
             e => panic!("cannot convert: {:?}", e),
         }
     }
@@ -283,9 +281,7 @@ fn gen_expr(node: Box<Node>) -> Option<usize> {
             add(IROp::Imm, r, Some(val as usize));
             return r;
         }
-        NodeType::Lvar(_) |
-        NodeType::Dot(_, _, _) |
-        NodeType::Gvar(_, _, _) => {
+        NodeType::Lvar(_) | NodeType::Dot(_, _, _) | NodeType::Gvar(_, _, _) => {
             let r = gen_lval(Box::new(node.clone()));
             load(&node.ty, r, r);
             return r;
@@ -374,8 +370,8 @@ fn gen_expr(node: Box<Node>) -> Option<usize> {
                     label(y);
                     return r1;
                 }
-                MulEQ | DivEQ | ModEQ | AddEQ | SubEQ | ShlEQ | ShrEQ | BitandEQ | XorEQ |
-                BitorEQ => gen_assign_op(&op, &node.ty, lhs, rhs),
+                MulEQ | DivEQ | ModEQ | AddEQ | SubEQ | ShlEQ | ShrEQ | BitandEQ | XorEQ
+                | BitorEQ => gen_assign_op(&op, &node.ty, lhs, rhs),
                 EQ => gen_binop(IROp::EQ, lhs, rhs),
                 NE => gen_binop(IROp::NE, lhs, rhs),
                 LE => gen_binop(IROp::LE, lhs, rhs),
@@ -538,8 +534,7 @@ fn gen_stmt(node: Node) {
             let r = gen_expr(expr);
             kill(r);
         }
-        NodeType::VecStmt(stmts) |
-        NodeType::CompStmt(stmts) => {
+        NodeType::VecStmt(stmts) | NodeType::CompStmt(stmts) => {
             for n in stmts {
                 gen_stmt(n);
             }

--- a/src/gen_x86.rs
+++ b/src/gen_x86.rs
@@ -1,6 +1,6 @@
-use gen_ir::{IROp, Function, IR};
+use gen_ir::{Function, IROp, IR};
 use util::roundup;
-use {REGS_N, Scope, Var};
+use {Scope, Var, REGS_N};
 
 const REGS: [&str; REGS_N] = ["r10", "r11", "rbx", "r12", "r13", "r14", "r15"];
 const REGS8: [&str; REGS_N] = ["r10b", "r11b", "bl", "r12b", "r13b", "r14b", "r15b"];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 #![feature(core_intrinsics, dbg_macro, drain_filter, exclusive_range_pattern)]
 
-pub mod gen_x86;
 pub mod gen_ir;
+pub mod gen_x86;
 pub mod irdump;
 pub mod parse;
-pub mod regalloc;
-pub mod token;
-pub mod sema;
 pub mod preprocess;
+pub mod regalloc;
+pub mod sema;
+pub mod token;
 mod util;
 
 #[macro_use]
@@ -18,72 +18,83 @@ const REGS_N: usize = 7;
 // Token type
 #[derive(Debug, PartialEq, Clone)]
 pub enum TokenType {
-    Num(i32), // Number literal
-    Str(String, usize), // String literal. (str, len)
+    Num(i32),            // Number literal
+    Str(String, usize),  // String literal. (str, len)
     CharLiteral(String), // Char literal.
-    Ident(String), // Identifier
-    Param(usize), // Function-like macro parameter
-    Arrow, // ->
-    Extern, // "extern"
-    Typedef, // "typedef"
-    Int, // "int"
-    Char, // "char"
-    Void, // "void"
-    Struct, // "struct"
-    Plus, // +
-    Minus, // -
-    Mul, // *
-    Div, // /
-    And, // &
-    Dot, // .
-    Comma, // ,
-    Exclamation, // !
-    Question, // ?
-    VerticalBar, // |
-    Hat, // ^
-    Colon, // :
-    HashMark, // #
-    If, // "if"
-    Else, // "else"
-    For, // "for"
-    Do, // "do"
-    While, // "while"
-    Break, // "break"
-    EQ, // ==
-    NE, // !=
-    LE, // <=
-    GE, // >=
-    Semicolon, // ;
-    LeftParen, // (
-    RightParen, // )
-    LeftBracket, // [
-    RightBracket, // ]
-    LeftBrace, // {
-    RightBrace, // }
-    LeftAngleBracket, // <
-    RightAngleBracket, // >
-    Equal, // =
-    Logor, // ||
-    Logand, // &&
-    SHL, // <<
-    Inc, // ++
-    Dec, // --
-    MulEQ, // *=
-    DivEQ, // /=
-    ModEQ, // %=
-    AddEQ, // +=
-    SubEQ, // -=
-    ShlEQ, // <<=
-    ShrEQ, // >>=
-    BitandEQ, // &=
-    XorEQ, // ^=
-    BitorEQ, // |=
-    SHR, // >>
-    Mod, // %
-    Return, // "return"
-    Sizeof, // "sizeof"
-    Alignof, // "_Alignof"
-    NewLine, // preprocessor-only token
+    Ident(String),       // Identifier
+    Param(usize),        // Function-like macro parameter
+    Arrow,               // ->
+    Extern,              // "extern"
+    Typedef,             // "typedef"
+    Int,                 // "int"
+    Char,                // "char"
+    Void,                // "void"
+    Struct,              // "struct"
+    Plus,                // +
+    Minus,               // -
+    Mul,                 // *
+    Div,                 // /
+    And,                 // &
+    Dot,                 // .
+    Comma,               // ,
+    Exclamation,         // !
+    Question,            // ?
+    VerticalBar,         // |
+    Hat,                 // ^
+    Colon,               // :
+    HashMark,            // #
+    If,                  // "if"
+    Else,                // "else"
+    For,                 // "for"
+    Do,                  // "do"
+    While,               // "while"
+    Break,               // "break"
+    EQ,                  // ==
+    NE,                  // !=
+    LE,                  // <=
+    GE,                  // >=
+    Semicolon,           // ;
+    LeftParen,           // (
+    RightParen,          // )
+    LeftBracket,         // [
+    RightBracket,        // ]
+    LeftBrace,           // {
+    RightBrace,          // }
+    LeftAngleBracket,    // <
+    RightAngleBracket,   // >
+    Equal,               // =
+    Logor,               // ||
+    Logand,              // &&
+    SHL,                 // <<
+    Inc,                 // ++
+    Dec,                 // --
+    MulEQ,               // *=
+    DivEQ,               // /=
+    ModEQ,               // %=
+    AddEQ,               // +=
+    SubEQ,               // -=
+    ShlEQ,               // <<=
+    ShrEQ,               // >>=
+    BitandEQ,            // &=
+    XorEQ,               // ^=
+    BitorEQ,             // |=
+    SHR,                 // >>
+    Mod,                 // %
+    Return,              // "return"
+    Sizeof,              // "sizeof"
+    Alignof,             // "_Alignof"
+    NewLine,             // preprocessor-only token
+}
+
+// Charactor Kind
+#[derive(Debug, PartialEq, Clone)]
+pub enum CharactorType {
+    Whitespace, // ' '
+    NewLine,    // ' \n'
+    Alphabetic,
+    Digit,
+    NonAlphabetic(char),
+    Unknown(char),
 }
 
 impl TokenType {
@@ -124,8 +135,8 @@ pub enum Ctype {
     Int,
     Char,
     Void,
-    Ptr(Box<Type>), // ptr of
-    Ary(Box<Type>, usize), // ary of, len
+    Ptr(Box<Type>),           // ptr of
+    Ary(Box<Type>, usize),    // ary of, len
     Struct(Vec<parse::Node>), // members
     Func(Box<Type>),
 }
@@ -139,7 +150,7 @@ impl Default for Ctype {
 #[derive(Debug, Clone)]
 pub struct Type {
     pub ty: Ctype,
-    pub size: usize, // sizeof
+    pub size: usize,  // sizeof
     pub align: usize, // alignof
 }
 
@@ -155,7 +166,7 @@ impl Default for Type {
 
 #[derive(Debug, Clone)]
 pub enum Scope {
-    Local(usize), // offset
+    Local(usize),                // offset
     Global(String, usize, bool), // data, len, is_extern
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub enum TokenType {
 }
 
 // Charactor Kind
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq)]
 pub enum CharactorType {
     Whitespace, // ' '
     NewLine,    // ' \n'

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 extern crate r9cc;
 
-use r9cc::gen_x86::gen_x86;
 use r9cc::gen_ir::gen_ir;
+use r9cc::gen_x86::gen_x86;
 use r9cc::irdump::dump_ir;
 use r9cc::parse::parse;
-use r9cc::regalloc::alloc_regs;
-use r9cc::token::tokenize;
-use r9cc::sema::sema;
 use r9cc::preprocess::Preprocessor;
+use r9cc::regalloc::alloc_regs;
+use r9cc::sema::sema;
+use r9cc::token::tokenize;
 
 use std::env;
 use std::process;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,6 +1,6 @@
 use token::Token;
-use {TokenType, Ctype, Type, Scope};
 use util::roundup;
+use {Ctype, Scope, TokenType, Type};
 
 use std::collections::HashMap;
 
@@ -60,41 +60,41 @@ macro_rules! new_expr(
 
 #[derive(Debug, Clone)]
 pub enum NodeType {
-    Num(i32), // Number literal
-    Str(String, usize), // String literal, (data, len)
-    Ident(String), // Identifier
-    Decl(String), // declaration
-    Vardef(String, Option<Box<Node>>, Scope), // Variable definition, name = init
-    Lvar(Scope), // Variable reference
-    Gvar(String, String, usize), // Variable reference, (name, data, len)
-    BinOp(TokenType, Box<Node>, Box<Node>), // left-hand, right-hand
-    If(Box<Node>, Box<Node>, Option<Box<Node>>), // "if" ( cond ) then "else" els
-    Ternary(Box<Node>, Box<Node>, Box<Node>), // cond ? then : els
+    Num(i32),                                        // Number literal
+    Str(String, usize),                              // String literal, (data, len)
+    Ident(String),                                   // Identifier
+    Decl(String),                                    // declaration
+    Vardef(String, Option<Box<Node>>, Scope),        // Variable definition, name = init
+    Lvar(Scope),                                     // Variable reference
+    Gvar(String, String, usize),                     // Variable reference, (name, data, len)
+    BinOp(TokenType, Box<Node>, Box<Node>),          // left-hand, right-hand
+    If(Box<Node>, Box<Node>, Option<Box<Node>>),     // "if" ( cond ) then "else" els
+    Ternary(Box<Node>, Box<Node>, Box<Node>),        // cond ? then : els
     For(Box<Node>, Box<Node>, Box<Node>, Box<Node>), // "for" ( init; cond; inc ) body
     Break,
     DoWhile(Box<Node>, Box<Node>), // do { body } while(cond)
-    Addr(Box<Node>), // address-of operator("&"), expr
-    Deref(Box<Node>), // pointer dereference ("*"), expr
+    Addr(Box<Node>),               // address-of operator("&"), expr
+    Deref(Box<Node>),              // pointer dereference ("*"), expr
     Dot(Box<Node>, String, usize), // Struct member accessm, (expr, name, offset)
-    Exclamation(Box<Node>), // !, expr
-    Neg(Box<Node>), // -
-    PostInc(Box<Node>), // post ++
-    PostDec(Box<Node>), // post --
-    Return(Box<Node>), // "return", stmt
-    Sizeof(Box<Node>), // "sizeof", expr
-    Alignof(Box<Node>), // "_Alignof", expr
-    Call(String, Vec<Node>), // Function call(name, args)
+    Exclamation(Box<Node>),        // !, expr
+    Neg(Box<Node>),                // -
+    PostInc(Box<Node>),            // post ++
+    PostDec(Box<Node>),            // post --
+    Return(Box<Node>),             // "return", stmt
+    Sizeof(Box<Node>),             // "sizeof", expr
+    Alignof(Box<Node>),            // "_Alignof", expr
+    Call(String, Vec<Node>),       // Function call(name, args)
     Func(String, Vec<Node>, Box<Node>, usize), // Function definition(name, args, body, stacksize)
-    CompStmt(Vec<Node>), // Compound statement
-    VecStmt(Vec<Node>), // For the purpose of assign a value when initializing an array.
-    ExprStmt(Box<Node>), // Expression statement
-    StmtExpr(Box<Node>), // Statement expression (GNU extn.)
+    CompStmt(Vec<Node>),           // Compound statement
+    VecStmt(Vec<Node>),            // For the purpose of assign a value when initializing an array.
+    ExprStmt(Box<Node>),           // Expression statement
+    StmtExpr(Box<Node>),           // Statement expression (GNU extn.)
     Null,
 }
 
 #[derive(Debug, Clone)]
 pub struct Node {
-    pub op: NodeType, // Node type
+    pub op: NodeType,  // Node type
     pub ty: Box<Type>, // C type
 }
 
@@ -570,8 +570,8 @@ impl<'a> Parser<'a> {
     fn assign_op(ty: &TokenType) -> Option<&TokenType> {
         use self::TokenType::*;
         match ty {
-            Equal | MulEQ | DivEQ | ModEQ | AddEQ | SubEQ | ShlEQ | ShrEQ | BitandEQ | XorEQ |
-            BitorEQ => Some(ty),
+            Equal | MulEQ | DivEQ | ModEQ | AddEQ | SubEQ | ShlEQ | ShrEQ | BitandEQ | XorEQ
+            | BitorEQ => Some(ty),
             _ => None,
         }
     }
@@ -639,9 +639,11 @@ impl<'a> Parser<'a> {
                 NodeType::Deref,
                 Node::new_binop(TokenType::Plus, ident.clone(), Node::new(NodeType::Num(i)))
             );
-            init.push(Node::new(NodeType::ExprStmt(
-                Box::new(Node::new_binop(TokenType::Equal, node, val)),
-            )));
+            init.push(Node::new(NodeType::ExprStmt(Box::new(Node::new_binop(
+                TokenType::Equal,
+                node,
+                val,
+            )))));
             if !self.consume(TokenType::Comma) {
                 break;
             }
@@ -665,7 +667,6 @@ impl<'a> Parser<'a> {
 
         if let TokenType::Ident(_) = t.ty {
             node = Node::new(NodeType::Vardef(self.ident(), None, Scope::Local(0)));
-
         } else if self.consume(TokenType::LeftParen) {
             node = self.declarator(&mut placeholder);
             self.expect(TokenType::RightParen);

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -1,11 +1,11 @@
 // C preprocessor
 
-use token::{Token, tokenize};
+use token::{tokenize, Token};
 use TokenType;
 
 use std::collections::HashMap;
-use std::rc::Rc;
 use std::mem;
+use std::rc::Rc;
 
 pub fn preprocess(tokens: Vec<Token>, ctx: &mut Preprocessor) -> Vec<Token> {
     ctx.preprocess_impl(tokens)
@@ -58,7 +58,6 @@ impl Macro {
     }
 
     fn replace_params(mut self) -> Self {
-
         match self.ty {
             MacroType::Funclike(ref params) => {
                 let mut map = HashMap::new();
@@ -89,7 +88,8 @@ impl Macro {
                 }
 
                 // Process '#' followed by a macro parameter.
-                self.tokens = self.tokens
+                self.tokens = self
+                    .tokens
                     .into_iter()
                     .scan(false, |is_prev_hashmark, mut t| {
                         if *is_prev_hashmark {
@@ -106,14 +106,17 @@ impl Macro {
 
                 let mut is_prev_stringize = false;
                 self.tokens.reverse();
-                self.tokens = self.tokens
+                self.tokens = self
+                    .tokens
                     .into_iter()
-                    .filter_map(|t| if is_prev_stringize && t.ty == TokenType::HashMark {
-                        is_prev_stringize = t.stringize;
-                        None
-                    } else {
-                        is_prev_stringize = t.stringize;
-                        Some(t)
+                    .filter_map(|t| {
+                        if is_prev_stringize && t.ty == TokenType::HashMark {
+                            is_prev_stringize = t.stringize;
+                            None
+                        } else {
+                            is_prev_stringize = t.stringize;
+                            Some(t)
+                        }
                     })
                     .collect::<Vec<_>>();
                 self.tokens.reverse();
@@ -123,7 +126,6 @@ impl Macro {
         self
     }
 }
-
 
 pub struct Preprocessor {
     macros: HashMap<String, Macro>,
@@ -163,8 +165,7 @@ impl Preprocessor {
     fn ident(&mut self, msg: &str) -> String {
         let t = self.next().expect(msg);
         match t.ty {
-            TokenType::Ident(s) |
-            TokenType::Str(s, _) => s,
+            TokenType::Ident(s) | TokenType::Str(s, _) => s,
             _ => t.bad_token(msg),
         }
     }
@@ -287,11 +288,9 @@ impl Preprocessor {
             match t.ty {
                 TokenType::Param(val) => {
                     if t.stringize {
-                        self.env.output.push(Self::stringize(
-                            &args[val],
-                            t.filename,
-                            t.buf,
-                        ));
+                        self.env
+                            .output
+                            .push(Self::stringize(&args[val], t.filename, t.buf));
                     } else {
                         self.env.output.append(&mut args[val].clone());
                     }
@@ -365,7 +364,6 @@ impl Preprocessor {
                 }
                 continue;
             }
-
 
             if t.ty != TokenType::HashMark {
                 self.env.output.push(t);

--- a/src/regalloc.rs
+++ b/src/regalloc.rs
@@ -1,4 +1,4 @@
-use gen_ir::{IROp, IR, IRType, Function};
+use gen_ir::{Function, IROp, IRType, IR};
 use irdump::IRInfo;
 use REGS_N;
 

--- a/src/sema.rs
+++ b/src/sema.rs
@@ -1,10 +1,10 @@
 use parse::{Node, NodeType};
 use util::roundup;
-use {TokenType, Ctype, Type, Scope, Var};
+use {Ctype, Scope, TokenType, Type, Var};
 
-use std::sync::Mutex;
 use std::collections::HashMap;
 use std::mem;
+use std::sync::Mutex;
 
 // Quoted from 9cc
 // > Semantics analyzer. This pass plays a few important roles as shown
@@ -40,7 +40,7 @@ fn swap(p: &mut Box<Node>, q: &mut Box<Node>) {
     mem::swap(p, q);
 }
 
-lazy_static!{
+lazy_static! {
     static ref GLOBALS: Mutex<Vec<Var>> = Mutex::new(vec![]);
     static ref ENV: Mutex<Env> = Mutex::new(Env::new(None));
     static ref STRLABEL: Mutex<usize> = Mutex::new(0);
@@ -104,8 +104,10 @@ fn maybe_decay(base: Node, decay: bool) -> Node {
 
 fn check_lval(node: &Node) {
     let op = &node.op;
-    if !matches!(op, NodeType::Lvar(_)) && !matches!(op, NodeType::Gvar(_, _, _)) &&
-        !matches!(op, NodeType::Deref(_)) && !matches!(op, NodeType::Dot(_, _, _))
+    if !matches!(op, NodeType::Lvar(_))
+        && !matches!(op, NodeType::Gvar(_, _, _))
+        && !matches!(op, NodeType::Deref(_))
+        && !matches!(op, NodeType::Dot(_, _, _))
     {
         panic!("not an lvalue: {:?}", node.op);
     }
@@ -243,14 +245,14 @@ fn walk(mut node: Node, decay: bool) -> Node {
                     lhs = Box::new(walk(*lhs, true));
                     rhs = Box::new(walk(*rhs, true));
 
-                    if matches!(rhs.ty.ty , Ctype::Ptr(_)) {
+                    if matches!(rhs.ty.ty, Ctype::Ptr(_)) {
                         swap(&mut lhs, &mut rhs);
                     }
-                    if matches!(rhs.ty.ty , Ctype::Ptr(_)) {
+                    if matches!(rhs.ty.ty, Ctype::Ptr(_)) {
                         panic!("'pointer {:?} pointer' is not defined", node.op)
                     }
 
-                    if matches!(lhs.ty.ty , Ctype::Ptr(_)) {
+                    if matches!(lhs.ty.ty, Ctype::Ptr(_)) {
                         rhs = Box::new(Node::scale_ptr(rhs, &lhs.ty));
                     }
 
@@ -262,7 +264,7 @@ fn walk(mut node: Node, decay: bool) -> Node {
                     check_lval(&*lhs);
                     rhs = Box::new(walk(*rhs, true));
 
-                    if matches!(lhs.ty.ty , Ctype::Ptr(_)) {
+                    if matches!(lhs.ty.ty, Ctype::Ptr(_)) {
                         rhs = Box::new(Node::scale_ptr(rhs, &lhs.ty));
                     }
                     node.op = BinOp(token_type, lhs.clone(), rhs);
@@ -375,8 +377,7 @@ pub fn sema(nodes: Vec<Node>) -> (Vec<Node>, Vec<Var>) {
 
         let mut var;
         match &node.op {
-            NodeType::Func(name, _, _, _) |
-            NodeType::Decl(name) => {
+            NodeType::Func(name, _, _, _) | NodeType::Decl(name) => {
                 var = Var::new_global(node.ty.clone(), name.clone(), "".into(), 0, false);
                 ENV.lock().unwrap().vars.insert(name.clone(), var);
             }
@@ -388,7 +389,6 @@ pub fn sema(nodes: Vec<Node>) -> (Vec<Node>, Vec<Var>) {
         }
 
         if let NodeType::Func(name, args, body, _) = node.op {
-
             let mut args2 = vec![];
             for arg in args {
                 args2.push(walk(arg, true));

--- a/src/token.rs
+++ b/src/token.rs
@@ -177,28 +177,24 @@ impl Tokenizer {
     }
 
     // This does not support non-ASCII charactors.
-    fn scan_char_type(ch: &char) -> CharactorType {
-        if ch == &'\n' {
-            CharactorType::NewLine
-        } else if ch == &' ' || ch == &'\t' {
-            CharactorType::Whitespace
-        } else if ch.is_alphabetic() || ch == &'_' {
-            CharactorType::Alphabetic
-        } else if ch.is_ascii_digit() {
-            CharactorType::Digit
-        } else {
-            CharactorType::NonAlphabetic(ch.clone())
-        }
-    }
-
-    fn get_word_head(&self, advance: usize) -> Option<CharactorType> {
-        self.p
-            .get(self.pos + advance)
-            .map(|c| Self::scan_char_type(c))
+    fn get_charactor(&self, advance_from_pos: usize) -> Option<CharactorType> {
+        self.p.get(self.pos + advance_from_pos).map(|ch| {
+            if ch == &'\n' {
+                CharactorType::NewLine
+            } else if ch == &' ' || ch == &'\t' {
+                CharactorType::Whitespace
+            } else if ch.is_alphabetic() || ch == &'_' {
+                CharactorType::Alphabetic
+            } else if ch.is_ascii_digit() {
+                CharactorType::Digit
+            } else {
+                CharactorType::NonAlphabetic(ch.clone())
+            }
+        })
     }
 
     fn scan(&mut self, keywords: &HashMap<String, TokenType>) -> Vec<Token> {
-        'outer: while let Some(head_char) = self.get_word_head(0) {
+        'outer: while let Some(head_char) = self.get_charactor(0) {
             match head_char {
                 CharactorType::NewLine => {
                     let mut t = self.new_token(TokenType::NewLine);

--- a/src/token.rs
+++ b/src/token.rs
@@ -192,11 +192,9 @@ impl Tokenizer {
     }
 
     fn get_word_head(&self, advance: usize) -> Option<CharactorType> {
-        if let Some(c) = self.p.get(self.pos + advance) {
-            Some(Self::scan_char_type(c))
-        } else {
-            None
-        }
+        self.p
+            .get(self.pos + advance)
+            .map(|c| Self::scan_char_type(c))
     }
 
     fn scan(&mut self, keywords: &HashMap<String, TokenType>) -> Vec<Token> {

--- a/src/token.rs
+++ b/src/token.rs
@@ -177,23 +177,23 @@ impl Tokenizer {
     }
 
     // This doesnt support non-ASCII charactors.
-    fn scan_char_type(ch: char) -> CharactorType {
-        if ch == '\n' {
+    fn scan_char_type(ch: &char) -> CharactorType {
+        if ch == &'\n' {
             CharactorType::NewLine
-        } else if ch == ' ' || ch == '\t' {
+        } else if ch == &' ' || ch == &'\t' {
             CharactorType::Whitespace
-        } else if ch.is_alphabetic() || ch == '_' {
+        } else if ch.is_alphabetic() || ch == &'_' {
             CharactorType::Alphabetic
         } else if ch.is_ascii_digit() {
             CharactorType::Digit
         } else {
-            CharactorType::NonAlphabetic(ch)
+            CharactorType::NonAlphabetic(ch.clone())
         }
     }
 
-    fn get_word_head(&mut self, advance: usize) -> Option<CharactorType> {
+    fn get_word_head(&self, advance: usize) -> Option<CharactorType> {
         if let Some(c) = self.p.get(self.pos + advance) {
-            Some(Self::scan_char_type(c.clone()))
+            Some(Self::scan_char_type(c))
         } else {
             None
         }

--- a/src/token.rs
+++ b/src/token.rs
@@ -176,7 +176,7 @@ impl Tokenizer {
         Token::new(ty, self.pos, self.filename.clone(), self.p.clone())
     }
 
-    // This doesnt support non-ASCII charactors.
+    // This does not support non-ASCII charactors.
     fn scan_char_type(ch: &char) -> CharactorType {
         if ch == &'\n' {
             CharactorType::NewLine
@@ -212,9 +212,7 @@ impl Tokenizer {
                 CharactorType::Alphabetic => self.ident(&keywords),
                 CharactorType::Digit => self.number(),
 
-                CharactorType::NonAlphabetic('\'') => {
-                    self.char_literal();
-                }
+                CharactorType::NonAlphabetic('\'') => self.char_literal(),
                 CharactorType::NonAlphabetic('\"') => self.string_literal(),
                 CharactorType::NonAlphabetic('/') => match self.p.get(self.pos + 1) {
                     Some('/') => self.line_comment(),
@@ -306,7 +304,7 @@ impl Tokenizer {
         }
     }
 
-    fn char_literal(&mut self) -> char {
+    fn char_literal(&mut self) {
         self.pos += 1;
         let result: char;
         let c = self.p.get(self.pos).expect("premature end of input");
@@ -332,7 +330,6 @@ impl Tokenizer {
         self.pos += 1;
         t.end = self.pos + 1;
         self.tokens.push(t);
-        return result;
     }
 
     fn string_literal(&mut self) {


### PR DESCRIPTION
Title: Make more readable code in tokenizer(src/token.rs), with match expression.
Auther: GnicoJP

[Original Token.rs Code](https://github.com/utam0k/r9cc/blob/7391bbc5565577ee6af3f3776333e12297a305e4/src/token.rs#L183) has if statements lined up within the while statement.  
That's difficult to understand all conditional branches, so Using match expression is more easier to read.
And I think we had better use enum and pattern matching. It decrease lines of function, and it gets more splittablility into functions.