### PR TITLE
`print!()` or `eprint!()` with a format string that ends in a single newline

### DIFF
--- a/src/gen_x86.rs
+++ b/src/gen_x86.rs
@@ -89,9 +89,9 @@ fn gen(f: Function) {
     let ret = format!(".Lend{}", *LABEL.lock().unwrap());
     *LABEL.lock().unwrap() += 1;
 
-    print!(".text\n");
-    print!(".global {}\n", f.name);
-    print!("{}:\n", f.name);
+    println!(".text");
+    println!(".global {}", f.name);
+    println!("{}:", f.name);
     emit!("push rbp");
     emit!("mov rbp, rsp");
     emit!("sub rsp, {}", roundup(f.stacksize, 16));
@@ -123,7 +123,7 @@ fn gen(f: Function) {
 
                 emit!("mov {}, rax", REGS[lhs]);
             }
-            Label => print!(".L{}:\n", lhs),
+            Label => println!(".L{}:", lhs),
             LabelAddr(name) => emit!("lea {}, {}", REGS[lhs], name),
             Neg => emit!("neg {}", REGS[lhs]),
             EQ => emit_cmp(ir, "sete"),
@@ -198,7 +198,7 @@ fn gen(f: Function) {
         }
     }
 
-    print!("{}:\n", ret);
+    println!("{}:", ret);
     emit!("pop r15");
     emit!("pop r14");
     emit!("pop r13");
@@ -209,14 +209,14 @@ fn gen(f: Function) {
 }
 
 pub fn gen_x86(globals: Vec<Var>, fns: Vec<Function>) {
-    print!(".intel_syntax noprefix\n");
-    print!(".data\n");
+    println!(".intel_syntax noprefix");
+    println!(".data");
     for var in globals {
         if let Scope::Global(data, len, is_extern) = var.scope {
             if is_extern {
                 continue;
             }
-            print!("{}:\n", var.name);
+            println!("{}:", var.name);
             emit!(".ascii \"{}\"", backslash_escape(data, len));
             continue;
         }

--- a/src/irdump.rs
+++ b/src/irdump.rs
@@ -104,9 +104,9 @@ impl fmt::Display for IR {
 
 pub fn dump_ir(fns: &Vec<Function>) {
     for f in fns {
-        eprint!("{}(): \n", f.name);
+        eprintln!("{}(): ", f.name);
         for ir in &f.ir {
-            eprint!("{}\n", ir);
+            eprintln!("{}", ir);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::env;
 use std::process;
 
 fn usage() -> ! {
-    eprint!("Usage: 9cc [-dump-ir1] [-dump-ir2] <file>\n");
+    eprintln!("Usage: 9cc [-dump-ir1] [-dump-ir2] <file>");
     process::exit(1)
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -528,7 +528,7 @@ fn print_line(buf: &Vec<char>, path: &String, pos: usize) {
         }
         print!("{}", p);
     }
-    print!("\n");
+    println!("");
     for _ in 0..col - 1 {
         print!(" ");
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -528,7 +528,7 @@ fn print_line(buf: &Vec<char>, path: &String, pos: usize) {
         }
         print!("{}", p);
     }
-    println!("");
+    println!();
     for _ in 0..col - 1 {
         print!(" ");
     }


### PR DESCRIPTION
clippy only warns `print!()`, but I also edited instances of `eprint!()`